### PR TITLE
Populate activity image

### DIFF
--- a/Laiban/Modules/Activities/Sources/Admin/ActivityAdminActivityView.swift
+++ b/Laiban/Modules/Activities/Sources/Admin/ActivityAdminActivityView.swift
@@ -47,6 +47,8 @@ struct ActivityAdminActivityView: View {
         var hasTimeRange = false
         var image:Image?
         init(activity:Activity) {
+            defer { populateImage() }
+            
             self.activity = activity
             self.date = activity.date
             self.content = activity.content


### PR DESCRIPTION
This is a fix for missing image in admin activities: Image was not displayed for activity in edit mode. 

### Testing
Test by creating an activity in admin with an image: 
Navigate to admin for activities (Inställningar -> Aktiviteter -> Lägg till aktivitet).
Create an activity with title and image by selecting "Lägg till bild".
Go back to "Aktivitet" and click on newly created activity under "Alla aktiviteter". The previously selected image shall be displayed at the top.