### PR TITLE
Added LocalAttireSuggestionProvider

### DIFF
--- a/Laiban/Modules/Outdoors/Sources/Models/WeatherExtensions.swift
+++ b/Laiban/Modules/Outdoors/Sources/Models/WeatherExtensions.swift
@@ -41,6 +41,20 @@ public extension Weather {
     }
 }
 public enum WeatherCondition:String, CaseIterable, Codable {
+    public enum SeasonalBreakPoint {
+        case winterStarts
+        case winterEnds
+        case autumnStarts
+        case springEnds
+        func dateString(year:Int) -> String {
+            switch self {
+            case .winterStarts: return "\(year)-11-01"
+            case .winterEnds: return "\(year)-03-31"
+            case .autumnStarts: return "\(year)-09-15"
+            case .springEnds: return "\(year)-05-15"
+            }
+        }
+    }
     case unknown
     case rainy
     case cold
@@ -61,10 +75,31 @@ public enum WeatherCondition:String, CaseIterable, Codable {
         if (20...Double(Int.max)).contains(temperature) { return .hot}
         return .unknown
     }
+    public static func condition(for temperature:Double, precipitation:Double) -> Self {
+        let c1 = condition(for: temperature)
+        if precipitation > 0 {
+            switch c1 {
+            case .cold: return .coldAndRainy
+            case .cool: return .coolAndRainy
+            default: return .rainy
+            }
+        }
+        return c1
+    }
     public var garments:[Garment] {
+        let date = Date()
+        let year = date.year
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let winterStarts   = dateFormatter.date(from: SeasonalBreakPoint.winterStarts.dateString(year: year))!
+        let winterEnds     = dateFormatter.date(from: SeasonalBreakPoint.winterEnds.dateString(year: year))!
+        let autumnStarts   = dateFormatter.date(from: SeasonalBreakPoint.autumnStarts.dateString(year: year))!
+        let springEnds     = dateFormatter.date(from: SeasonalBreakPoint.springEnds.dateString(year: year))!
+        return garments(date: date, winterStarts: winterStarts, winterEnds: winterEnds, autumnStarts: autumnStarts, springEnds: springEnds)
+    }
+    func garments(date:Date, winterStarts:Date,winterEnds:Date,autumnStarts:Date,springEnds:Date) -> [Garment] {
         var arr = Set(baseGarments)
-        let now = Date()
-        if now > date(month: "11", day: "01")  || now < date(month: "03", day: "31") {
+        if date > winterStarts  || date < winterEnds {
             arr.remove(.pulloverPants)
             arr.remove(.jacket)
             arr.remove(.cap)
@@ -73,7 +108,7 @@ public enum WeatherCondition:String, CaseIterable, Codable {
             arr.insert(.neckwear)
             arr.insert(.beanie)
             arr.insert(.mittens)
-        } else if isCold && (now > date(month: "09", day: "15") || now < date(month: "05", day: "15")) {
+        } else if isCold && (date > autumnStarts || date < springEnds) {
             arr.insert(.beanie)
             arr.insert(.mittens)
             arr.remove(.cap)
@@ -96,16 +131,4 @@ public enum WeatherCondition:String, CaseIterable, Codable {
     public var isCold:Bool {
         [Self.cold, Self.coldAndRainy].contains(self)
     }
-}
-/// Creates a date object based on the given data
-/// - Parameters:
-///   - year: the year
-///   - month: the month (leading 0)
-///   - day: the day (leading 0)
-/// - Returns: a date object based on the given parameters
-fileprivate func date(month:String,day:String) -> Date!{
-    let garmentDF = DateFormatter()
-    garmentDF.dateFormat = "yyyy-MM-dd"
-    
-    return garmentDF.date(from: "\(Date().year)-\(month)-\(day)")
 }

--- a/Laiban/Modules/Outdoors/Sources/Services/LocalAttireSuggestionProvider/LBAttireSuggestionGarmentProvider.swift
+++ b/Laiban/Modules/Outdoors/Sources/Services/LocalAttireSuggestionProvider/LBAttireSuggestionGarmentProvider.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Combine
+
+fileprivate let regex = try! NSRegularExpression(pattern: "(^[ft]{14}$)")
+
+public actor LBAttireSuggestionGarmentProvider : AttireSuggestionGarmentProvider {
+    typealias SeasonalBreakPoint = WeatherCondition.SeasonalBreakPoint
+    private var dateformatter:DateFormatter
+    private var winterStarts:Date
+    private var winterEnds:Date
+    private var autumnStarts:Date
+    private var springEnds:Date
+    private var currentYear:Int
+    public init() {
+        self.dateformatter = DateFormatter()
+        self.dateformatter.dateFormat = "yyyy-MM-d"
+        
+        self.currentYear    = Calendar(identifier: .gregorian).component(.year, from: Date())
+        self.winterStarts   = dateformatter.date(from: SeasonalBreakPoint.winterStarts.dateString(year: currentYear))!
+        self.winterEnds     = dateformatter.date(from: SeasonalBreakPoint.winterEnds.dateString(year: currentYear))!
+        self.autumnStarts   = dateformatter.date(from: SeasonalBreakPoint.autumnStarts.dateString(year: currentYear))!
+        self.springEnds     = dateformatter.date(from: SeasonalBreakPoint.springEnds.dateString(year: currentYear))!
+    }
+    public func getEncodedAttire(date: Date, temperature: Double, precipitation: Double) -> String {
+        let condition = WeatherCondition.condition(for: temperature, precipitation: precipitation)
+        let garments = self.garments(condition: condition, for: date)
+        return Garment.string(from: garments)
+    }
+    nonisolated public func validate(encodedAttire string:String) throws {
+        if !regex.matches(string) {
+            throw LocalAttireSuggestionError.attireEntryInvalid(string)
+        }
+    }
+    private func garments(condition:WeatherCondition, for date:Date) -> [Garment] {
+        let year = Calendar(identifier: .gregorian).component(.year, from: date)
+        if year != currentYear {
+            self.currentYear    = year
+            self.winterStarts   = dateformatter.date(from: SeasonalBreakPoint.winterStarts.dateString(year: year))!
+            self.winterEnds     = dateformatter.date(from: SeasonalBreakPoint.winterEnds.dateString(year: year))!
+            self.autumnStarts   = dateformatter.date(from: SeasonalBreakPoint.autumnStarts.dateString(year: year))!
+            self.springEnds     = dateformatter.date(from: SeasonalBreakPoint.springEnds.dateString(year: year))!
+        }
+        return condition.garments(date: date, winterStarts: winterStarts, winterEnds: winterEnds, autumnStarts: autumnStarts, springEnds: springEnds)
+    }
+}

--- a/Laiban/Modules/Outdoors/Sources/Services/LocalAttireSuggestionProvider/LocalAttireSuggestionProvider.swift
+++ b/Laiban/Modules/Outdoors/Sources/Services/LocalAttireSuggestionProvider/LocalAttireSuggestionProvider.swift
@@ -1,0 +1,395 @@
+import Foundation
+import Weather
+
+fileprivate let regex = try! NSRegularExpression(pattern: #"\W"#)
+
+public enum LocalAttireSuggestionError : Error {
+    case noResult
+    case platformNotSupported
+    case missingDefaultTrainingData
+    case missingMlModel
+    case notEnoughDataToTrain
+    case temperatureEntryInvalid(Double)
+    case humidityEntryInvalid(Double)
+    case dewPointEntryInvalid(Double)
+    case windSpeedEntryInvalid(Double)
+    case windGustSpeedEntryInvalid(Double)
+    case windDirectionEntryInvalid(Double)
+    case airPressureEntryInvalid(Double)
+    case totalPrecipitationEntryInvalid(Double)
+    case attireEntryInvalid(String)
+}
+
+public protocol AttireSuggestionGarmentProvider {
+    func getEncodedAttire(date:Date, temperature:Double, precipitation:Double) async -> String
+    func validate(encodedAttire:String) throws
+}
+public protocol LocalAttireSuggestionDataProvider {
+    func generateData(writeCSVTo url:URL) async throws
+}
+
+#if canImport(CreateMLComponents) && canImport(TabularData)
+import CreateMLComponents
+import TabularData
+#endif
+
+/// `LocalAttireSuggestionProvider` uses a tablular classficication model to train and predict what types of clothes once should wear depending on a number of weather parameters
+public actor LocalAttireSuggestionProvider {
+    /// Clothes predction results
+    public struct Results {
+        /// Encoded list of garments,, see `Garment` for more information
+        public let attire:String
+        /// The probability/accuracy of the prediction in % (0-1)
+        public let probability:Double
+    }
+    public struct UpdateEntry : Codable {
+        public let temperature:Double
+        public let humidity:Double
+        public let dewPoint:Double
+        public let windSpeed:Double
+        public let windGustSpeed:Double
+        public let windDirection:Double
+        public let airPressure:Double
+        public let totalPrecipitation:Double
+        public let attire:String
+
+        public init (
+            temperature:Double,
+            humidity:Double,
+            dewPoint:Double,
+            windSpeed:Double,
+            windGustSpeed:Double,
+            windDirection:Double,
+            airPressure:Double,
+            totalPrecipitation:Double,
+            attire:String
+        ) {
+            self.temperature = temperature
+            self.humidity = humidity
+            self.dewPoint = dewPoint
+            self.windSpeed = windSpeed
+            self.windGustSpeed = windGustSpeed
+            self.windDirection = windDirection
+            self.airPressure = airPressure
+            self.totalPrecipitation = totalPrecipitation
+            self.attire = attire
+        }
+        
+        public func validate(using provider:AttireSuggestionGarmentProvider) throws {
+            if temperature < -273.15 {
+                throw LocalAttireSuggestionError.temperatureEntryInvalid(temperature)
+            }
+            if humidity < 0 || humidity > 100{
+                throw LocalAttireSuggestionError.humidityEntryInvalid(humidity)
+            }
+            if dewPoint < -273.15 {
+                throw LocalAttireSuggestionError.dewPointEntryInvalid(dewPoint)
+            }
+            if windSpeed < 0 {
+                throw LocalAttireSuggestionError.windSpeedEntryInvalid(windSpeed)
+            }
+            if windGustSpeed < 0 {
+                throw LocalAttireSuggestionError.windGustSpeedEntryInvalid(windGustSpeed)
+            }
+            if windDirection > 360 || windDirection < -360 {
+                throw LocalAttireSuggestionError.windDirectionEntryInvalid(windDirection)
+            }
+            if airPressure < 0 {
+                throw LocalAttireSuggestionError.airPressureEntryInvalid(airPressure)
+            }
+            if totalPrecipitation < 0 {
+                throw LocalAttireSuggestionError.totalPrecipitationEntryInvalid(totalPrecipitation)
+            }
+            try provider.validate(encodedAttire: attire)
+        }
+    }
+    let defaultDataURL:URL?
+    let dataURL:URL
+    let modelURL:URL
+    let labelsURL:URL
+    let garmentProvider:AttireSuggestionGarmentProvider
+    /// Initializes a new `LocalAttireSuggestionGenerator`
+    /// - Parameters:
+    ///   - defaultDataURL: Default data provided, default value is `Bundle.main.url(forResource: "data", withExtension: "csv")`
+    ///   - libraryFolderName: App library folder name, only word characters and no spaces, defautls to `"LocalAttireSuggestions"`
+    public init(defaultDataURL:URL? = Bundle.main.url(forResource: "data", withExtension: "csv"), libraryFolderName:String = "LocalAttireSuggestions", garmentProvider:AttireSuggestionGarmentProvider) {
+        var libraryFolderName = libraryFolderName
+        if regex.matches(libraryFolderName) {
+            print("⛔️ [\(#fileID):\(#function):\(#line)] " + "libraryFolderName not valid, using default instead")
+            libraryFolderName = "LocalAttireSuggestions"
+        }
+        self.garmentProvider = garmentProvider
+        self.defaultDataURL = defaultDataURL
+        let storageDirectory = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0].appendingPathComponent(libraryFolderName)
+        
+        if FileManager.default.fileExists(atPath: storageDirectory.path) == false {
+            do {
+                try FileManager.default.createDirectory(at: storageDirectory, withIntermediateDirectories: true, attributes: [FileAttributeKey.protectionKey: FileProtectionType.complete])
+            } catch {
+                fatalError("⛔️ [\(#fileID):\(#function):\(#line)] " + String(describing: error))
+            }
+        }
+        dataURL = storageDirectory.appendingPathComponent("TrainingData.csv")
+        modelURL = storageDirectory.appendingPathComponent("AttireSuggestorModel.pkg")
+        labelsURL = storageDirectory.appendingPathComponent("Labels.json")
+    }
+    
+    /// Indicates whether or not the generator is supported on the speciic platform.
+    /// Unsupported platforms are:
+    /// - iOS/iPadOS before 16
+    /// - macOS before 13 (including iOS 16 simluators runing on macOS 12)
+    public static var isSupported:Bool {
+        var res:Bool = true
+        #if canImport(CreateMLComponents) && canImport(TabularData)
+        res = true
+        #else
+        res = false
+        #endif
+        return res
+    }
+    
+    /// Indicates whether or not the generator requires precition model training
+    public var requiresTraining:Bool {
+        return !FileManager.default.fileExists(atPath: modelURL.path) || !FileManager.default.fileExists(atPath: labelsURL.path)
+    }
+    
+    #if canImport(CreateMLComponents) && canImport(TabularData)
+    static let classifierColumn = ColumnID(DataColumn.attire.rawValue, String.self)
+    public enum DataColumn: String, CaseIterable {
+        case temperature
+        case humidity
+        case dewPoint
+        case windSpeed
+        case windGustSpeed
+        case windDirection
+        case airPressure
+        case totalPrecipitation
+        case attire
+        var csvType:CSVType {
+            switch self {
+            case .attire: return .string
+            default: return .double
+            }
+        }
+        static var csvTypes:[String : CSVType] {
+            var dict = [String : CSVType]()
+            for a in allCases {
+                dict[a.rawValue] = a.csvType
+            }
+            return dict
+        }
+        static var featureColumns:[String] {
+            var cols = allCases
+            cols.removeLast()
+            return cols.map { $0.rawValue }
+        }
+        static var columns:[String] {
+            allCases.map { $0.rawValue }
+        }
+    }
+    
+    private func task(with labels:Set<String>) -> some SupervisedTabularEstimator {
+        return BoostedTreeClassifier(labels: labels, annotationColumnName: DataColumn.attire.rawValue, featureColumnNames: DataColumn.featureColumns)
+    }
+    
+    private func getDataFrame() throws -> DataFrame {
+        if FileManager.default.fileExists(atPath: dataURL.path) {
+            return try DataFrame(contentsOfCSVFile: dataURL, columns: DataColumn.columns,types: DataColumn.csvTypes)
+        }
+        guard let defaultDataURL else {
+            throw LocalAttireSuggestionError.missingDefaultTrainingData
+        }
+        let frame = try DataFrame(contentsOfCSVFile: defaultDataURL, columns: DataColumn.columns,types: DataColumn.csvTypes)
+        try frame.writeCSV(to: dataURL)
+        return frame
+    }
+    
+    private func _train(using dataFrame:DataFrame) async throws {
+        let col = dataFrame[Self.classifierColumn]
+        var labels = Set<String>()
+        for a in col.distinct() {
+            guard let val = a else {
+                continue
+            }
+            labels.insert(val)
+        }
+        try JSONEncoder().encode(labels).write(to: labelsURL)
+        if labels.count < 3 {
+            throw LocalAttireSuggestionError.notEnoughDataToTrain
+        }
+        //MARK: Train model
+        let task = task(with: labels)
+        let (training, validation) = dataFrame.randomSplit(by: 0.8)
+        let transformer = try await task.fitted(to: DataFrame(training), validateOn: DataFrame(validation)) { event in
+            guard let validationError = event.metrics[.validationError] as? Double else {
+                return
+            }
+            print("⛔️ [\(#fileID):\(#function):\(#line)] " + String(describing: validationError))
+        }
+        try task.write(transformer, to: modelURL)
+    }
+    private func createDataFrame(using entries:[UpdateEntry]) -> DataFrame {
+        return [
+            DataColumn.temperature.rawValue:        entries.map{ $0.temperature },
+            DataColumn.humidity.rawValue:           entries.map{ $0.humidity },
+            DataColumn.dewPoint.rawValue:           entries.map{ $0.dewPoint },
+            DataColumn.windSpeed.rawValue:          entries.map{ $0.windSpeed },
+            DataColumn.windGustSpeed.rawValue:      entries.map{ $0.windGustSpeed },
+            DataColumn.windDirection.rawValue:      entries.map{ $0.windDirection },
+            DataColumn.airPressure.rawValue:        entries.map{ $0.airPressure },
+            DataColumn.totalPrecipitation.rawValue: entries.map{ $0.totalPrecipitation },
+            DataColumn.attire.rawValue:            entries.map{ $0.attire }
+        ]
+    }
+    
+    private func _update(using entries:[UpdateEntry], trainAfterUpdate:Bool = true) async throws {
+        for e in entries {
+            try e.validate(using: garmentProvider)
+        }
+        var dataFrame:DataFrame
+        do {
+            dataFrame = try getDataFrame()
+            for entry in entries {
+                dataFrame.append(valuesByColumn: [
+                    DataColumn.temperature.rawValue:        entry.temperature,
+                    DataColumn.humidity.rawValue:           entry.humidity,
+                    DataColumn.dewPoint.rawValue:           entry.dewPoint,
+                    DataColumn.windSpeed.rawValue:          entry.windSpeed,
+                    DataColumn.windGustSpeed.rawValue:      entry.windGustSpeed,
+                    DataColumn.windDirection.rawValue:      entry.windDirection,
+                    DataColumn.airPressure.rawValue:        entry.airPressure,
+                    DataColumn.totalPrecipitation.rawValue: entry.totalPrecipitation,
+                    DataColumn.attire.rawValue:            entry.attire
+                ])
+            }
+        } catch {
+            dataFrame = createDataFrame(using: entries)
+        }
+        try dataFrame.writeCSV(to: dataURL)
+        if trainAfterUpdate {
+            try await _train(using: dataFrame)
+        }
+    }
+    private func _resetTrainingData(using entries:[UpdateEntry], trainAfterUpdate:Bool = true) async throws {
+        deleteContent()
+        for e in entries {
+            try e.validate(using: garmentProvider)
+        }
+        let dataFrame:DataFrame = createDataFrame(using: entries)
+        try dataFrame.writeCSV(to: dataURL)
+        if trainAfterUpdate {
+            try await _train(using: dataFrame)
+        }
+    }
+    private func _resetTrainingDataToDefaults() throws {
+        guard let defaultDataURL else {
+            throw LocalAttireSuggestionError.missingDefaultTrainingData
+        }
+        let frame = try DataFrame(contentsOfCSVFile: defaultDataURL, columns: DataColumn.columns,types: DataColumn.csvTypes)
+        try frame.writeCSV(to: dataURL)
+    }
+    
+    private func _resetTrainingDataUsing(provider:LocalAttireSuggestionDataProvider) async throws {
+        try await provider.generateData(writeCSVTo: dataURL)
+    }
+    
+    private func _train() async throws {
+        let dataFrame = try getDataFrame()
+        if FileManager.default.fileExists(atPath: modelURL.path) {
+            try dataFrame.writeCSV(to: dataURL)
+        }
+        try await _train(using: dataFrame)
+    }
+    
+    private func _predict(temperature:Double, humidity:Double, dewPoint:Double, windSpeed:Double, windGustSpeed:Double, windDirection:Double, airPressure:Double, totalPrecipitation:Double) async throws -> [Results] {
+        if requiresTraining {
+            throw LocalAttireSuggestionError.missingMlModel
+        }
+        let labels = try JSONDecoder().decode(Set<String>.self, from: try Data(contentsOf: labelsURL))
+        let model = try task(with: labels).read(from: modelURL)
+        let dataFrame: DataFrame = [
+            DataColumn.temperature.rawValue:        [temperature],
+            DataColumn.humidity.rawValue:           [humidity],
+            DataColumn.dewPoint.rawValue:           [dewPoint],
+            DataColumn.windSpeed.rawValue:          [windSpeed],
+            DataColumn.windGustSpeed.rawValue:      [windGustSpeed],
+            DataColumn.windDirection.rawValue:      [windDirection],
+            DataColumn.airPressure.rawValue:        [airPressure],
+            DataColumn.totalPrecipitation.rawValue: [totalPrecipitation]
+        ]
+        let result = try await model(dataFrame)
+        guard let val = result["\(DataColumn.attire.rawValue)Probability"][0] as? CreateMLComponents.ClassificationDistribution<String> else {
+            throw LocalAttireSuggestionError.noResult
+        }
+        return val.map { Results(attire: $0.label, probability: Double($0.probability)) }
+    }
+    #endif
+    
+    public func deleteContent() {
+        try? FileManager.default.removeItem(at: dataURL)
+        try? FileManager.default.removeItem(at: labelsURL)
+        try? FileManager.default.removeItem(at: modelURL)
+    }
+    /// Update the prediction model using custom entries.
+    /// - Parameter entries: entries with weather and clothes
+    /// - Parameter trainAfterUpdate: train model after update
+    public func update(using entries:[UpdateEntry], trainAfterUpdate:Bool = true) async throws {
+        #if canImport(CreateMLComponents) && canImport(TabularData)
+        try await _update(using: entries, trainAfterUpdate:trainAfterUpdate)
+        #else
+        throw LocalAttireSuggestionError.platformNotSupported
+        #endif
+    }
+    
+    /// Reset the prediction model data using default data
+    public func resetTrainingDataToDefaults() throws {
+        #if canImport(CreateMLComponents) && canImport(TabularData)
+        try _resetTrainingDataToDefaults()
+        #else
+        throw LocalAttireSuggestionError.platformNotSupported
+        #endif
+    }
+    public func resetTrainingData(using entries:[UpdateEntry], trainAfterUpdate:Bool = true) async throws {
+        #if canImport(CreateMLComponents) && canImport(TabularData)
+        try await _resetTrainingData(using: entries, trainAfterUpdate:trainAfterUpdate)
+        #else
+        throw LocalAttireSuggestionError.platformNotSupported
+        #endif
+    }
+    /// Reset the prediction model using data from SMHI weather service using latitude and longitude
+    public func resetTrainingDataUsing(provider:LocalAttireSuggestionDataProvider) async throws {
+        #if canImport(CreateMLComponents) && canImport(TabularData)
+        try await _resetTrainingDataUsing(provider: provider)
+        #else
+        throw LocalAttireSuggestionError.platformNotSupported
+        #endif
+    }
+    
+    /// Train using the latest data provided, either locally or from default file
+    public func train() async throws {
+        #if canImport(CreateMLComponents) && canImport(TabularData)
+        try await _train()
+        #else
+        throw LocalAttireSuggestionError.platformNotSupported
+        #endif
+    }
+    
+    /// Predict what kind of clothes once should wear based on the provided paramerters
+    /// - Parameters:
+    ///   - temperature: the temperature in celcius°
+    ///   - humidity: humidity, from 0 to 100
+    ///   - dewPoint: dewpoint in celcius°
+    ///   - windSpeed: windspeed in meters per second
+    ///   - windGustSpeed: windGustSpeed in meters per second
+    ///   - windDirection: windDirection in degrees
+    ///   - airPressure: air pressure in mbar
+    ///   - totalPrecipitation:  mm/h
+    /// - Returns: prediction results
+    public func predict(temperature:Double, humidity:Double, dewPoint:Double, windSpeed:Double, windGustSpeed:Double, windDirection:Double, airPressure:Double, totalPrecipitation:Double) async throws -> [Results] {
+        #if canImport(CreateMLComponents) && canImport(TabularData)
+        try await _predict(temperature: temperature, humidity: humidity, dewPoint: dewPoint, windSpeed: windSpeed, windGustSpeed: windGustSpeed, windDirection: windDirection, airPressure: airPressure, totalPrecipitation: totalPrecipitation)
+        #else
+        throw LocalAttireSuggestionError.platformNotSupported
+        #endif
+    }
+}

--- a/Laiban/Modules/Outdoors/Sources/Services/LocalAttireSuggestionProvider/LocalAttireSuggestionProviderExample.swift
+++ b/Laiban/Modules/Outdoors/Sources/Services/LocalAttireSuggestionProvider/LocalAttireSuggestionProviderExample.swift
@@ -1,0 +1,89 @@
+//import SwiftUI
+//import Weather
+//import Combine
+//
+//@MainActor class AttireSuggestionService : ObservableObject {
+//    enum Status:String {
+//        case booting
+//        case training
+//        case ready
+//        case failed
+//    }
+//    let garmentProvider:LBAttireSuggestionGarmentProvider
+//    let dataProvider:SMHIAttireSuggestionDataProvider
+//    let attireProvider:LocalAttireSuggestionProvider
+//    let weather = Weather(service: SMHIForecastService())
+//    let latitude:Double = 59.323840
+//    let longitude:Double = 13.466290
+//    var cancellables = Set<AnyCancellable>()
+//    @Published var status:Status = .booting
+//    @Published var weatherData:WeatherData?
+//    @Published var garments:[Garment] = []
+//    init() {
+//        let gp = LBAttireSuggestionGarmentProvider()
+//        garmentProvider = gp
+//        // Use period "corrected-archive" to train a complete model (it takes a few minutes)
+//        dataProvider = SMHIAttireSuggestionDataProvider(latitude: latitude, longitude: longitude, period: "latest-months", garmentProvider: gp)
+//        attireProvider = LocalAttireSuggestionProvider(garmentProvider: gp)
+//        weather.coordinates = .init(latitude: latitude, longitude: longitude)
+//
+//        Task {
+//            do {
+//                status = .training
+//                if await attireProvider.requiresTraining {
+//                    try await attireProvider.resetTrainingDataUsing(provider: dataProvider)
+//                    try await attireProvider.train()
+//                }
+//                status = .ready
+//                predictAttire()
+//            } catch {
+//                status = .failed
+//                print("⛔️ [\(#fileID):\(#function):\(#line)] " + String(describing: error))
+//            }
+//        }
+//        weather.closest().sink { data in
+//            self.weatherData = data
+//            self.predictAttire()
+//        }.store(in: &cancellables)
+//    }
+//    func predictAttire() {
+//        Task {
+//            guard let data = weatherData else {
+//                return
+//            }
+//            if await attireProvider.requiresTraining {
+//                return
+//            }
+//            guard let result = try await attireProvider.predict(
+//                temperature: data.airTemperature,
+//                humidity: Double(data.relativeHumidity),
+//                dewPoint: Weather.dewPointAdjustedTemperature(humidity: Double(data.relativeHumidity), temperature: data.airTemperature),
+//                windSpeed: data.windSpeed,
+//                windGustSpeed: data.windGustSpeed,
+//                windDirection: data.windDirection,
+//                airPressure: data.airPressure,
+//                totalPrecipitation: data.maxPrecipitation
+//            ).first else {
+//                print("⛔️ [\(#fileID):\(#function):\(#line)] " + "no result?")
+//                return
+//            }
+//            self.garments = Garment.garments(from: result.attire)
+//        }
+//    }
+//}
+//
+//struct AttireSuggestionView: View {
+//    @ObservedObject var attireSuggestionService:AttireSuggestionService
+//    var body: some View {
+//        VStack {
+//            Text("Status: \(attireSuggestionService.status.rawValue)")
+//            if attireSuggestionService.weatherData != nil {
+//                Text("Temperature: \(attireSuggestionService.weatherData!.airTemperatureFeelsLike)°")
+//            }
+//            ForEach(attireSuggestionService.garments) { garment in
+//                Text(garment.rawValue)
+//            }
+//        }
+//        .padding()
+//    }
+//}

--- a/Laiban/Modules/Outdoors/Sources/Services/LocalAttireSuggestionProvider/SMHIAttireSuggestionDataProvider.swift
+++ b/Laiban/Modules/Outdoors/Sources/Services/LocalAttireSuggestionProvider/SMHIAttireSuggestionDataProvider.swift
@@ -1,0 +1,131 @@
+import Foundation
+import Combine
+import Weather
+#if canImport(CreateMLComponents) && canImport(TabularData)
+import TabularData
+#endif
+
+public enum SMHIAttireSuggestionDataProviderError: Error {
+    case latitudeMissing
+    case longitudeMissing
+    case periodMissing
+    case garmentProviderMissing
+    case unsupportedPlatform
+}
+public actor SMHIAttireSuggestionDataProvider : LocalAttireSuggestionDataProvider {
+    public private(set) var latitude:Double? = nil
+    public private(set) var longitude:Double? = nil
+    public private(set) var period:String? = nil
+    public private(set) var garmentProvider:AttireSuggestionGarmentProvider? = nil
+    private var cancellables = Set<AnyCancellable>()
+
+    public init(latitude:Double?, longitude:Double?, period:String?, garmentProvider:AttireSuggestionGarmentProvider?) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.period = period
+        self.garmentProvider = garmentProvider
+    }
+    public func update(latitude:Double?, longitude:Double?, period:String?, garmentProvider:AttireSuggestionGarmentProvider?) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.period = period
+        self.garmentProvider = garmentProvider
+    }
+    private func makeAsync<T:Any>(_ publisher:AnyPublisher<T,Error>) async throws -> T  {
+        return try await withCheckedThrowingContinuation { continuation in
+            publisher.sink { compl in
+                if case let .failure(err) = compl {
+                    continuation.resume(throwing: err)
+                }
+            } receiveValue: { val in
+                continuation.resume(returning: val)
+            }.store(in: &cancellables)
+        }
+    }
+    #if canImport(CreateMLComponents) && canImport(TabularData)
+    private func createFrame(with values:SMHIObservations.Value, for property:String) -> DataFrame {
+        let vals = values.value.filter { Double($0.value) != nil }
+        return [
+            "date": vals.map{ $0.date },
+            "\(property)": vals.map{ Double($0.value) },
+        ]
+    }
+    #endif
+    public func generateData(writeCSVTo url: URL) async throws {
+        #if canImport(CreateMLComponents) && canImport(TabularData)
+        typealias DataColumn = LocalAttireSuggestionProvider.DataColumn
+        guard let latitude else {
+            throw SMHIAttireSuggestionDataProviderError.latitudeMissing
+        }
+        guard let longitude else {
+            throw SMHIAttireSuggestionDataProviderError.longitudeMissing
+        }
+        guard let period else {
+            throw SMHIAttireSuggestionDataProviderError.periodMissing
+        }
+        guard let garmentProvider else {
+            throw SMHIAttireSuggestionDataProviderError.garmentProviderMissing
+        }
+        async let temperature         = makeAsync(SMHIObservations.publisher(latitude: latitude, longitude: longitude, parameter: "1",  period: period))
+        async let windGustSpeed       = makeAsync(SMHIObservations.publisher(latitude: latitude, longitude: longitude, parameter: "21", period: period))
+        async let windSpeed           = makeAsync(SMHIObservations.publisher(latitude: latitude, longitude: longitude, parameter: "4",  period: period))
+        async let airPressure         = makeAsync(SMHIObservations.publisher(latitude: latitude, longitude: longitude, parameter: "9",  period: period))
+        async let humidity            = makeAsync(SMHIObservations.publisher(latitude: latitude, longitude: longitude, parameter: "6",  period: period))
+        async let dewPoint            = makeAsync(SMHIObservations.publisher(latitude: latitude, longitude: longitude, parameter: "39", period: period))
+        async let windDirection       = makeAsync(SMHIObservations.publisher(latitude: latitude, longitude: longitude, parameter: "3",  period: period))
+        async let totalPrecipitation  = makeAsync(SMHIObservations.publisher(latitude: latitude, longitude: longitude, parameter: "7",  period: period))
+        
+        let temperatureFrame          = createFrame(with: try await temperature,        for: DataColumn.temperature.rawValue)
+        let windGustSpeedFrame        = createFrame(with: try await windGustSpeed,      for: DataColumn.windGustSpeed.rawValue)
+        let windSpeedFrame            = createFrame(with: try await windSpeed,          for: DataColumn.windSpeed.rawValue)
+        let airPressureFrame          = createFrame(with: try await airPressure,        for: DataColumn.airPressure.rawValue)
+        let humidityFrame             = createFrame(with: try await humidity,           for: DataColumn.humidity.rawValue)
+        let dewPointFrame             = createFrame(with: try await dewPoint,           for: DataColumn.dewPoint.rawValue)
+        let windDirectionFrame        = createFrame(with: try await windDirection,      for: DataColumn.windDirection.rawValue)
+        let totalPrecipitationFrame   = createFrame(with: try await totalPrecipitation, for: DataColumn.totalPrecipitation.rawValue)
+        
+        var frame:DataFrame = temperatureFrame
+        
+        frame = frame.joined(windGustSpeedFrame,        on: "date", kind: .left)
+        frame = frame.joined(windSpeedFrame,            on: "date", kind: .left)
+        frame = frame.joined(airPressureFrame,          on: "date", kind: .left)
+        frame = frame.joined(humidityFrame,             on: "date", kind: .left)
+        frame = frame.joined(dewPointFrame,             on: "date", kind: .left)
+        frame = frame.joined(windDirectionFrame,        on: "date", kind: .left)
+        frame = frame.joined(totalPrecipitationFrame,   on: "date", kind: .left)
+        
+        for c in frame.columns {
+            frame.renameColumn(c.name, to: String(c.name.split(separator: ".").last!))
+        }
+
+        var garmentDict = [Date:String]()
+        for row in frame.rows {
+            guard let t = row[DataColumn.temperature.rawValue] as? Double else {
+                continue
+            }
+            guard let p = row[DataColumn.totalPrecipitation.rawValue] as? Double  else {
+                continue
+            }
+            guard let d = row["date"] as? Date else {
+                continue
+            }
+            garmentDict[d] = await garmentProvider.getEncodedAttire(date: d, temperature: t, precipitation: p)
+        }
+        let garmentFrame:DataFrame = [
+            "date": garmentDict.map{ $0.key },
+            DataColumn.attire.rawValue: garmentDict.map{ $0.value },
+        ]
+        frame = frame.joined(garmentFrame, on: "date", kind: .left)
+        for c in frame.columns {
+            frame.renameColumn(c.name, to: String(c.name.split(separator: ".").last!))
+        }
+        let slice = frame.filter {
+            $0.contains { $0 == nil } != true
+        }
+        frame = DataFrame(slice)
+        try frame.writeCSV(to: url)
+        #else
+        throw SMHIAttireSuggestionDataProviderError.unsupportedPlatform
+        #endif
+    }
+}

--- a/Laiban/Shared/Extensions/NSRegularExpressionExtensions.swift
+++ b/Laiban/Shared/Extensions/NSRegularExpressionExtensions.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by Tomas Green on 2022-10-10.
+//
+
+import Foundation
+extension NSRegularExpression {
+    func matches(_ string: String) -> Bool {
+        let range = NSRange(location: 0, length: string.utf16.count)
+        return firstMatch(in: string, options: [], range: range) != nil
+    }
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/helsingborg-stad/spm-daisy",
       "state" : {
-        "revision" : "66cca9d9ef8fcc2cc21830c3ad6e9d71b980372d",
-        "version" : "1.0.4"
+        "revision" : "fafd15043203368165fb53431c3c1ff455946a30",
+        "version" : "1.0.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/SDWebImage/SDWebImageSwiftUI.git", from: "2.0.0"),
         //.package(url: "https://github.com/ashleymills/Reachability.swift.git", from: "5.1.0"),
-        .package(url: "https://github.com/helsingborg-stad/spm-daisy", from: "1.0.4")
+        .package(url: "https://github.com/helsingborg-stad/spm-daisy", from: "1.0.5")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Added a LocalAttireSuggestionProvider to train a model and predict clothes based on current weather conditions.

The provider can be used to train a model on device and update it continuously with user input. It can also be used to generate a pkg-model you can bundle with the app.

To learn more, take a look at the `LocalAttireSuggestionProviderExample.swift` file.

## Observe!
The provider has not been integrated with the Outdoors module.

## Supported platforms
- iOS/iPadOS 16 
- Mac OS 13 (does not work with iOS 16 simulator running on macOS 12)