### PR TITLE
Feat/admin enable module button

### DIFF
--- a/Laiban/Modules/Food/Sources/Admin/FoodAdminView.swift
+++ b/Laiban/Modules/Food/Sources/Admin/FoodAdminView.swift
@@ -37,6 +37,9 @@ struct FoodAdminView: View {
             //            NavigationLink(destination: AdminFoodWasteView(model: model, wasteManager: appState.foodWasteManager)) {
             //                Text("Matsvinn")
             //            }.id("FoodWasteStatistics")
+
+            Toggle("Visa på startskärmen", isOn: $service.data.showOnDashboard)
+                .disabled(service.data.foodLink == nil)
         }
         .onReceive(service.$data) { _ in
             service.save()

--- a/Laiban/Modules/Food/Sources/Admin/FoodAdminView.swift
+++ b/Laiban/Modules/Food/Sources/Admin/FoodAdminView.swift
@@ -39,6 +39,7 @@ struct FoodAdminView: View {
             //            }.id("FoodWasteStatistics")
 
             Toggle("Visa på startskärmen", isOn: $service.data.showOnDashboard)
+                .foregroundColor(service.data.foodLink != nil ? .blue : .gray)
                 .disabled(service.data.foodLink == nil)
         }
         .onReceive(service.$data) { _ in

--- a/Laiban/Modules/Food/Sources/Models/FoodServiceModel.swift
+++ b/Laiban/Modules/Food/Sources/Models/FoodServiceModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Meals
 
-public struct FoodServiceModel: Equatable, Decodable, Encodable {
+public struct FoodServiceModel: LBServiceModel, Equatable, Decodable, Encodable {
 //    var unitCode: String = ""
     public var foodProcessingMethod = FoodProcessingMethod.wordFilter
     public var foodLink: Skolmaten.School? = nil

--- a/Laiban/Modules/Food/Sources/Models/FoodServiceModel.swift
+++ b/Laiban/Modules/Food/Sources/Models/FoodServiceModel.swift
@@ -14,4 +14,5 @@ public struct FoodServiceModel: Equatable, Decodable, Encodable {
     public var foodLink: Skolmaten.School? = nil
 //    var maxFoodWastePerPerson: Int = 300
 //    var maxNumberOfPeoapleEating: Int = 50
+    public var showOnDashboard: Bool = false
 }

--- a/Laiban/Modules/Food/Sources/Services/FoodService.swift
+++ b/Laiban/Modules/Food/Sources/Services/FoodService.swift
@@ -91,7 +91,7 @@ public class FoodService: CTS<FoodServiceModel, FoodProcessingStorageService>, L
         
         self.$data.sink { model in
             self.mealsService.service = model.foodLink
-            self.isAvailable = model.foodLink != nil
+            self.isAvailable = model.foodLink != nil && model.showOnDashboard
             // makes sure that the translation script is triggered
             if model.foodProcessingMethod != self.data.foodProcessingMethod {
                 self.mealsService.fetch(force: true)

--- a/Laiban/Modules/Memory/Sources/Admin/MemoryGameServiceAdminView.swift
+++ b/Laiban/Modules/Memory/Sources/Admin/MemoryGameServiceAdminView.swift
@@ -19,6 +19,7 @@ struct MemoryGameServiceAdminView: View {
             Toggle("Slumpa bland aktiva spel", isOn: $service.data.memoryGamesAtRandomEnabled)
                 .disabled(service.data.defaultMemoryGames.count < 2)
             Toggle("Visa på startskärmen", isOn: $service.data.showOnDashboard)
+                .disabled(service.data.defaultMemoryGames.count < 1)
         }
     }
     var body: some View {

--- a/Laiban/Modules/Memory/Sources/Admin/MemoryGameServiceAdminView.swift
+++ b/Laiban/Modules/Memory/Sources/Admin/MemoryGameServiceAdminView.swift
@@ -10,16 +10,22 @@ import SwiftUI
 struct MemoryGameServiceAdminView: View {
     @ObservedObject var service:MemoryGameService
     var group: some View {
-        Group {
+        let gamesCount = service.data.defaultMemoryGames.count
+        return Group {
             NavigationLink(destination: MemoryGameServiceGamesAdminView(service: service)){
                 Text("Aktiva memoryspel")
                 Spacer()
-                Text("\(service.data.defaultMemoryGames.count)")
+                Text("\(gamesCount)")
             }
             Toggle("Slumpa bland aktiva spel", isOn: $service.data.memoryGamesAtRandomEnabled)
-                .disabled(service.data.defaultMemoryGames.count < 2)
+                .disabled(gamesCount < 2)
             Toggle("Visa på startskärmen", isOn: $service.data.showOnDashboard)
-                .disabled(service.data.defaultMemoryGames.count < 1)
+                .onAppear {
+                    if gamesCount < 1 {
+                        service.data.showOnDashboard = false
+                    }
+                }
+                .disabled(gamesCount < 1)
         }
     }
     var body: some View {

--- a/Laiban/Modules/Memory/Sources/Admin/MemoryGameServiceAdminView.swift
+++ b/Laiban/Modules/Memory/Sources/Admin/MemoryGameServiceAdminView.swift
@@ -18,6 +18,7 @@ struct MemoryGameServiceAdminView: View {
             }
             Toggle("Slumpa bland aktiva spel", isOn: $service.data.memoryGamesAtRandomEnabled)
                 .disabled(service.data.defaultMemoryGames.count < 2)
+            Toggle("Visa på startskärmen", isOn: $service.data.showOnDashboard)
         }
     }
     var body: some View {

--- a/Laiban/Modules/Memory/Sources/Models/DefaultMemoryGame.swift
+++ b/Laiban/Modules/Memory/Sources/Models/DefaultMemoryGame.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct MemoryGameServiceModel: Codable, Equatable {
+public struct MemoryGameServiceModel: LBServiceModel, Codable, Equatable {
     public var defaultMemoryGames:[DefaultMemoryGame] = []
     public var memoryGamesAtRandomEnabled:Bool = false
     public var showOnDashboard: Bool = false

--- a/Laiban/Modules/Memory/Sources/Models/DefaultMemoryGame.swift
+++ b/Laiban/Modules/Memory/Sources/Models/DefaultMemoryGame.swift
@@ -10,6 +10,7 @@ import Foundation
 public struct MemoryGameServiceModel: Codable, Equatable {
     public var defaultMemoryGames:[DefaultMemoryGame] = []
     public var memoryGamesAtRandomEnabled:Bool = false
+    public var showOnDashboard: Bool = false
 }
 
 

--- a/Laiban/Modules/Memory/Sources/Services/MemoryGameService.swift
+++ b/Laiban/Modules/Memory/Sources/Services/MemoryGameService.swift
@@ -25,7 +25,7 @@ public class MemoryGameService : CTS<MemoryGameServiceModel,CodableLocalJSONServ
     public convenience init() {
         self.init(emptyValue: MemoryGameServiceModel(), storageOptions: .init(filename: "MemoryGameData", foldername: "MemoryGameService"))
         self.$data.sink { model in
-            self.isAvailable = model.defaultMemoryGames.isEmpty == false
+            self.isAvailable = !model.defaultMemoryGames.isEmpty && model.showOnDashboard
         }.store(in: &cancellabled)
     }
 }

--- a/Laiban/Shared/Protocols/LBServiceModel.swift
+++ b/Laiban/Shared/Protocols/LBServiceModel.swift
@@ -1,0 +1,12 @@
+//
+//  File.swift
+//  
+//
+//  Created by Dan Nilsson on 2024-01-09.
+//
+
+import Foundation
+
+public protocol LBServiceModel {
+    var showOnDashboard: Bool { get, set }
+}

--- a/Laiban/Shared/Protocols/LBServiceModel.swift
+++ b/Laiban/Shared/Protocols/LBServiceModel.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 public protocol LBServiceModel {
-    var showOnDashboard: Bool { get, set }
+    var showOnDashboard: Bool { get set }
 }


### PR DESCRIPTION
Lagt till möjligheten att aktivera och avaktivera moduler via admin-panelen.

Se modul 'Memoryspel' samt 'Matsedel'

Testa via admin-panelen genom att klicka på 'Visa på startskärmen' för respektive modul som ska aktiveras eller avaktiveras.

Checka ut denna branch och bygg som vanligt via exempelappen.